### PR TITLE
Enable unstable 'test' crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 
 #![crate_type = "lib"]
 #![crate_name = "lazysort"]
+#![feature(test)]
 
 extern crate test;
 extern crate rand;


### PR DESCRIPTION
Surpresses `error: use of unstable library feature 'test'`
