### PR TITLE
Add benchmark methods to use std::collections::BinaryHeap for comparison

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,8 @@ mod tests {
 
     use std::cmp::Ordering::Equal;
 
+    use std::collections::BinaryHeap;
+
     #[test]
     fn single_test() {
         let expected: Vec<u64> = vec![1];
@@ -328,7 +330,23 @@ mod tests {
     static VEC_SIZE: u64 = 50000;
     static PICK_SIZE_A: usize = 1000;
     static PICK_SIZE_B: usize = 10000;
-    static PICK_SIZE_C: usize = *&VEC_SIZE as usize;
+    static PICK_SIZE_C: usize = 50000;
+
+    #[cfg(feature="nightly")]
+    #[bench]
+    fn a_heap_bench(b: &mut Bencher) {
+        let mut rng = rand::thread_rng();
+        let between = Range::new(0u64, RANGE);
+        let numbers_raw: Vec<u64> = (0u64..VEC_SIZE).map(|_| between.ind_sample(&mut rng)).collect();
+
+        b.iter(|| {
+            let mut heap = BinaryHeap::from(numbers_raw.clone());
+            let mut v = Vec::new();
+            for _ in 0..PICK_SIZE_A {
+                v.push(heap.pop().unwrap());
+	    }
+        });
+    }
 
     #[cfg(feature="nightly")]
     #[bench]
@@ -360,6 +378,22 @@ mod tests {
 
     #[cfg(feature="nightly")]
     #[bench]
+    fn b_heap_bench(b: &mut Bencher) {
+        let mut rng = rand::thread_rng();
+        let between = Range::new(0u64, RANGE);
+        let numbers_raw: Vec<u64> = (0u64..VEC_SIZE).map(|_| between.ind_sample(&mut rng)).collect();
+
+        b.iter(|| {
+            let mut heap = BinaryHeap::from(numbers_raw.clone());
+            let mut v = Vec::new();
+            for _ in 0..PICK_SIZE_B {
+                v.push(heap.pop().unwrap());
+	    }
+        });
+    }
+
+    #[cfg(feature="nightly")]
+    #[bench]
     fn b_standard_bench(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
         let between = Range::new(0u64, RANGE);
@@ -383,6 +417,22 @@ mod tests {
             let numbers = numbers_raw.clone();
 
             let _: Vec<&u64> = numbers.iter().sorted().take(PICK_SIZE_B).collect();
+        });
+    }
+
+    #[cfg(feature="nightly")]
+    #[bench]
+    fn c_heap_bench(b: &mut Bencher) {
+        let mut rng = rand::thread_rng();
+        let between = Range::new(0u64, RANGE);
+        let numbers_raw: Vec<u64> = (0u64..VEC_SIZE).map(|_| between.ind_sample(&mut rng)).collect();
+
+        b.iter(|| {
+            let mut heap = BinaryHeap::from(numbers_raw.clone());
+            let mut v = Vec::new();
+            for _ in 0..PICK_SIZE_C {
+                v.push(heap.pop().unwrap());
+	    }
         });
     }
 


### PR DESCRIPTION
This patch adds three benchmarks that perform a similar operation using
Binary Heaps, which are commonly used for priority queues. The comparison
isn't perfect as the vectors have type `std::vec::Vec<u64>` rather than
`std::vec::Vec<&u64>` and the largest elements are removed rather than the
smallest elements.

Several example runs:

test tests::a_heap_bench     ... bench:     362,943 ns/iter (+/- 3,949)
test tests::a_lazy_bench     ... bench:   1,120,751 ns/iter (+/- 12,440)
test tests::a_standard_bench ... bench:   2,247,331 ns/iter (+/- 19,660)
test tests::b_heap_bench     ... bench:   1,098,852 ns/iter (+/- 14,080)
test tests::b_lazy_bench     ... bench:   1,601,322 ns/iter (+/- 34,577)
test tests::b_standard_bench ... bench:   2,259,301 ns/iter (+/- 16,198)
test tests::c_heap_bench     ... bench:   3,683,587 ns/iter (+/- 58,522)
test tests::c_lazy_bench     ... bench:   6,761,345 ns/iter (+/- 91,334)
test tests::c_standard_bench ... bench:   2,307,510 ns/iter (+/- 86,608)

test tests::a_heap_bench     ... bench:     365,398 ns/iter (+/- 35,629)
test tests::a_lazy_bench     ... bench:   1,118,628 ns/iter (+/- 15,792)
test tests::a_standard_bench ... bench:   2,249,310 ns/iter (+/- 122,616)
test tests::b_heap_bench     ... bench:   1,104,328 ns/iter (+/- 14,938)
test tests::b_lazy_bench     ... bench:   1,845,654 ns/iter (+/- 11,883)
test tests::b_standard_bench ... bench:   2,261,545 ns/iter (+/- 42,781)
test tests::c_heap_bench     ... bench:   3,538,444 ns/iter (+/- 38,194)
test tests::c_lazy_bench     ... bench:   6,085,003 ns/iter (+/- 124,096)
test tests::c_standard_bench ... bench:   2,310,726 ns/iter (+/- 81,551)

test tests::a_heap_bench     ... bench:     361,912 ns/iter (+/- 11,706)
test tests::a_lazy_bench     ... bench:   1,193,463 ns/iter (+/- 21,144)
test tests::a_standard_bench ... bench:   2,247,726 ns/iter (+/- 130,823)
test tests::b_heap_bench     ... bench:   1,100,707 ns/iter (+/- 12,372)
test tests::b_lazy_bench     ... bench:   1,517,510 ns/iter (+/- 17,052)
test tests::b_standard_bench ... bench:   2,262,166 ns/iter (+/- 19,240)
test tests::c_heap_bench     ... bench:   3,746,013 ns/iter (+/- 51,150)
test tests::c_lazy_bench     ... bench:   6,725,736 ns/iter (+/- 236,312)
test tests::c_standard_bench ... bench:   2,316,675 ns/iter (+/- 141,278)

Thanks to David Tolnay for feedback on earlier iterations and pointing out
the remaining differences with the existing benchmarks.