### PR TITLE
Rehabilitate lazysort; use static dispatch for benchmarks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ mod benches {
 
     use self::rand::distributions::{IndependentSample, Range};
 
-    use super::Sorted;
+    use super::SortedBy;
 
     use std::cmp::Ordering;
     use std::collections::BinaryHeap;
@@ -361,7 +361,7 @@ mod benches {
         b.iter(|| {
             let numbers = black_box(&input).clone();
 
-            let pick: Vec<u64> = numbers.into_iter().sorted().take(PICK_SIZE_A).collect();
+            let pick: Vec<u64> = numbers.into_iter().sorted_by(Ord::cmp).take(PICK_SIZE_A).collect();
             black_box(pick)
         });
     }
@@ -400,7 +400,7 @@ mod benches {
         b.iter(|| {
             let numbers = black_box(&input).clone();
 
-            let pick: Vec<u64> = numbers.into_iter().sorted().take(PICK_SIZE_B).collect();
+            let pick: Vec<u64> = numbers.into_iter().sorted_by(Ord::cmp).take(PICK_SIZE_B).collect();
             black_box(pick)
         });
     }
@@ -439,7 +439,7 @@ mod benches {
         b.iter(|| {
             let numbers = black_box(&input).clone();
 
-            let pick: Vec<u64> = numbers.into_iter().sorted().take(PICK_SIZE_C).collect();
+            let pick: Vec<u64> = numbers.into_iter().sorted_by(Ord::cmp).take(PICK_SIZE_C).collect();
             black_box(pick)
         });
     }


### PR DESCRIPTION
Problem: lazy sort's .sorted() uses a function pointer for the
comparison. Calling through a function pointer is known as virtual
dispatch, and if the compiler can't translate that back to static
dispatch through devirtualization, then we have virtual call overhead.
This makes the comparison with .sort() and BinaryHeap unfair.

Proposed Solution: Fix .sorted() to use static dispatch in the next major version.

local results (show a big improvement):

```
test benches::a_heap_bench     ... bench:     354,054 ns/iter (+/- 5,278)
test benches::a_lazy_bench     ... bench:     376,453 ns/iter (+/- 22,853)
test benches::a_standard_bench ... bench:   3,202,741 ns/iter (+/- 101,769)
test benches::b_heap_bench     ... bench:   1,075,371 ns/iter (+/- 45,413)
test benches::b_lazy_bench     ... bench:   1,056,641 ns/iter (+/- 49,884)
test benches::b_standard_bench ... bench:   3,313,681 ns/iter (+/- 294,452)
test benches::c_heap_bench     ... bench:   3,713,321 ns/iter (+/- 236,979)
test benches::c_lazy_bench     ... bench:   3,960,629 ns/iter (+/- 156,475)
test benches::c_standard_bench ... bench:   3,372,774 ns/iter (+/- 161,264)
```